### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server implementation for Fivetran management. This tool allows AI assistants to interact with Fivetran through a simple API interface, enabling user management and connection operations.
 
+<a href="https://glama.ai/mcp/servers/@andrewkkchan/mcp_fivetran">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andrewkkchan/mcp_fivetran/badge" alt="Fivetran MCP server" />
+</a>
+
 ## Local Client Integration
 
 To use this server with local MCP clients (like Claude Desktop), add the following configuration to your client settings:


### PR DESCRIPTION
This PR adds a badge for the [MCP Fivetran](https://glama.ai/mcp/servers/@andrewkkchan/mcp_fivetran) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@andrewkkchan/mcp_fivetran">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andrewkkchan/mcp_fivetran/badge" alt="Fivetran MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.